### PR TITLE
feat: 添加 Docker 支持及部署教程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Create data directory
+RUN mkdir -p data logs
+
+# Expose port
+EXPOSE 8000
+
+# Environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Run the application
+CMD ["python", "webui.py"]

--- a/README.md
+++ b/README.md
@@ -182,6 +182,57 @@ codex-register-v2/
 | `ws://host/api/ws/task/{uuid}` | 单任务实时日志 |
 | `ws://host/api/ws/batch/{id}` | 批量任务实时状态 |
 
+## Docker 部署
+
+### 环境要求
+
+- Docker
+- Docker Compose
+
+### 快速部署
+
+```bash
+# 克隆项目
+git clone https://github.com/cnlimiter/codex-register.git
+cd codex-register
+
+# 启动服务
+docker-compose up -d
+```
+
+服务启动后访问 http://localhost:8000
+
+### 配置说明
+
+**端口映射**：默认 `8000` 端口，可在 `docker-compose.yml` 中修改。
+
+**数据持久化**：
+```yaml
+volumes:
+  - ./data:/app/data
+  - ./logs:/app/logs
+```
+
+**代理配置**：
+```yaml
+environment:
+  - HTTP_PROXY=http://your-proxy:port
+  - HTTPS_PROXY=http://your-proxy:port
+```
+
+### 常用命令
+
+```bash
+# 查看日志
+docker-compose logs -f
+
+# 停止服务
+docker-compose down
+
+# 重新构建
+docker-compose build --no-cache
+```
+
 ## 注意事项
 
 - 首次运行会自动创建 `data/` 目录和 SQLite 数据库

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  codex-register:
+    build: .
+    container_name: codex-register
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    environment:
+      - PYTHONUNBUFFERED=1
+    restart: unless-stopped
+    # 如果需要代理，取消下面注释并修改地址
+    # environment:
+    #   - HTTP_PROXY=http://your-proxy:port
+    #   - HTTPS_PROXY=http://your-proxy:port


### PR DESCRIPTION
为项目添加 Docker 支持，方便用户快速部署。

## 改动内容

- 添加 Dockerfile (基于 Python 3.10-slim)
- 添加 docker-compose.yml (数据持久化配置)
- 更新 README.md (添加 Docker 部署教程)

## 测试验证

已通过构建和运行测试，Web UI 正常访问。

## 使用方式

git clone https://github.com/cnlimiter/codex-register.git
cd codex-register
docker-compose up -d
