### PR TITLE
Fix version format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-register-v2"
-version = "1.0,4"
+version = "1.0.4"
 description = "OpenAI 自动注册系统 v2"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
版本号敲错了，点打成逗号了

```
uv sync
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 3, column 11
  |
3 | version = "1.0,4"
  |           ^^^^^^^
after parsing `1.0`, found `,4`, which is not part of a valid version
```