### PR TITLE
fix: avoid matching 6-digit numbers inside email addresses

### DIFF
--- a/src/services/custom_domain.py
+++ b/src/services/custom_domain.py
@@ -326,8 +326,9 @@ class CustomDomainEmailService(BaseEmailService):
                     if "openai" not in sender and "openai" not in content.lower():
                         continue
 
-                    # 提取验证码
-                    match = re.search(pattern, content)
+                    # 提取验证码 过滤掉邮箱
+                    email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
+                    match = re.search(pattern, re.sub(email_pattern, "", content))
                     if match:
                         code = match.group(1)
                         logger.info(f"从自定义域名邮箱 {email} 找到验证码: {code}")


### PR DESCRIPTION
Fix false positive verification code matches caused by 6-digit numbers inside email addresses.

This change removes email addresses from the content before applying the verification code regex, so numeric substrings in email names are not incorrectly extracted as verification codes.