### PR TITLE
fix: 修复 issue #80 重复取码命中旧验证码的问题

### DIFF
--- a/src/services/base.py
+++ b/src/services/base.py
@@ -5,6 +5,7 @@
 
 import abc
 import logging
+from datetime import datetime
 from typing import Optional, Dict, Any, List
 from enum import Enum
 
@@ -45,6 +46,8 @@ class BaseEmailService(abc.ABC):
         self.name = name or f"{service_type.value}_service"
         self._status = EmailServiceStatus.HEALTHY
         self._last_error = None
+        self._used_verification_codes: Dict[str, set] = {}
+        self._seen_verification_messages: Dict[str, set] = {}
 
     @property
     def status(self) -> EmailServiceStatus:
@@ -162,6 +165,100 @@ class BaseEmailService(abc.ABC):
             if email_info.get("id") == email_id:
                 return email_info
         return None
+
+    def _get_used_verification_codes(self, email: str) -> set:
+        """获取邮箱对应的已使用验证码集合。"""
+        key = str(email or "").strip().lower()
+        if key not in self._used_verification_codes:
+            self._used_verification_codes[key] = set()
+        return self._used_verification_codes[key]
+
+    def _get_seen_verification_messages(self, email: str) -> set:
+        """获取邮箱对应的已处理消息标识集合。"""
+        key = str(email or "").strip().lower()
+        if key not in self._seen_verification_messages:
+            self._seen_verification_messages[key] = set()
+        return self._seen_verification_messages[key]
+
+    def _remember_verification_code(self, email: str, code: str) -> bool:
+        """记录验证码；若已用过则返回 False。"""
+        used_codes = self._get_used_verification_codes(email)
+        if code in used_codes:
+            return False
+        used_codes.add(code)
+        return True
+
+    def _remember_verification_message(self, email: str, message_marker: Optional[str]) -> bool:
+        """记录消息标识；若已处理过则返回 False。"""
+        if not message_marker:
+            return True
+
+        seen_messages = self._get_seen_verification_messages(email)
+        if message_marker in seen_messages:
+            return False
+        seen_messages.add(message_marker)
+        return True
+
+    def _accept_verification_code(
+        self,
+        email: str,
+        code: str,
+        message_marker: Optional[str] = None,
+    ) -> bool:
+        """
+        决定是否接受验证码。
+
+        若有可靠的新邮件标识，优先按消息去重，这样新邮件即便验证码重复也能被接受；
+        否则退回到按验证码去重，避免旧码被重复消费。
+        """
+        if message_marker:
+            if not self._remember_verification_message(email, message_marker):
+                return False
+            self._get_used_verification_codes(email).add(code)
+            return True
+
+        return self._remember_verification_code(email, code)
+
+    def _parse_message_timestamp(self, value: Any) -> Optional[float]:
+        """将常见邮件时间字段解析为 Unix 时间戳。"""
+        if value is None or value == "":
+            return None
+
+        if isinstance(value, datetime):
+            return value.timestamp()
+
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        text = str(value).strip()
+        if not text:
+            return None
+
+        try:
+            return float(text)
+        except ValueError:
+            pass
+
+        normalized = text.replace("Z", "+00:00") if text.endswith("Z") else text
+        try:
+            return datetime.fromisoformat(normalized).timestamp()
+        except ValueError:
+            return None
+
+    def _is_message_before_otp(self, message_time: Any, otp_sent_at: Optional[float], tolerance_seconds: int = 1) -> bool:
+        """
+        判断邮件是否早于当前 OTP 发送窗口。
+
+        允许少量时钟误差，避免接口时间与本地时间有轻微偏移时误伤新邮件。
+        """
+        if not otp_sent_at:
+            return False
+
+        message_ts = self._parse_message_timestamp(message_time)
+        if message_ts is None:
+            return False
+
+        return message_ts + tolerance_seconds < otp_sent_at
 
     def wait_for_email(
         self,

--- a/src/services/duck_mail.py
+++ b/src/services/duck_mail.py
@@ -269,6 +269,7 @@ class DuckMailService(BaseEmailService):
                         continue
 
                     seen_message_ids.add(message_id)
+                    message_marker = f"id:{message_id}"
                     detail = self._make_request(
                         "GET",
                         f"/messages/{message_id}",
@@ -281,8 +282,11 @@ class DuckMailService(BaseEmailService):
 
                     match = re.search(pattern, content)
                     if match:
+                        code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         self.update_status(True)
-                        return match.group(1)
+                        return code
             except Exception as e:
                 logger.debug(f"DuckMail 轮询验证码失败: {e}")
 

--- a/src/services/freemail.py
+++ b/src/services/freemail.py
@@ -216,6 +216,13 @@ class FreemailService(BaseEmailService):
                         continue
 
                     seen_mail_ids.add(mail_id)
+                    message_marker = f"id:{mail_id}"
+
+                    if self._is_message_before_otp(
+                        mail.get("created_at") or mail.get("createdAt") or mail.get("received_at") or mail.get("receivedAt"),
+                        otp_sent_at,
+                    ):
+                        continue
 
                     sender = str(mail.get("sender", "")).lower()
                     subject = str(mail.get("subject", ""))
@@ -229,6 +236,8 @@ class FreemailService(BaseEmailService):
                     # 尝试直接使用 Freemail 提取的验证码
                     v_code = mail.get("verification_code")
                     if v_code:
+                        if not self._accept_verification_code(email, str(v_code), message_marker):
+                            continue
                         logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {v_code}")
                         self.update_status(True)
                         return v_code
@@ -237,6 +246,8 @@ class FreemailService(BaseEmailService):
                     match = re.search(pattern, content)
                     if match:
                         code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {code}")
                         self.update_status(True)
                         return code
@@ -248,6 +259,8 @@ class FreemailService(BaseEmailService):
                         match = re.search(pattern, full_content)
                         if match:
                             code = match.group(1)
+                            if not self._accept_verification_code(email, code, message_marker):
+                                continue
                             logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {code}")
                             self.update_status(True)
                             return code

--- a/src/services/moe_mail.py
+++ b/src/services/moe_mail.py
@@ -310,6 +310,13 @@ class MeoMailEmailService(BaseEmailService):
                         continue
 
                     seen_message_ids.add(message_id)
+                    message_marker = f"id:{message_id}"
+
+                    if self._is_message_before_otp(
+                        message.get("created_at") or message.get("createdAt") or message.get("received_at") or message.get("receivedAt"),
+                        otp_sent_at,
+                    ):
+                        continue
 
                     # 检查是否是目标邮件
                     sender = str(message.get("from_address", "")).lower()
@@ -331,6 +338,8 @@ class MeoMailEmailService(BaseEmailService):
                     match = re.search(pattern, re.sub(email_pattern, "", content))
                     if match:
                         code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         logger.info(f"从自定义域名邮箱 {email} 找到验证码: {code}")
                         self.update_status(True)
                         return code

--- a/src/services/temp_mail.py
+++ b/src/services/temp_mail.py
@@ -330,6 +330,13 @@ class TempMailService(BaseEmailService):
                         continue
 
                     seen_mail_ids.add(mail_id)
+                    message_marker = f"id:{mail_id}"
+
+                    if self._is_message_before_otp(
+                        mail.get("createdAt") or mail.get("created_at") or mail.get("receivedAt") or mail.get("received_at"),
+                        otp_sent_at,
+                    ):
+                        continue
 
                     parsed = self._extract_mail_fields(mail)
                     sender = parsed["sender"].lower()
@@ -345,6 +352,8 @@ class TempMailService(BaseEmailService):
                     match = re.search(pattern, content)
                     if match:
                         code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         logger.info(f"从 TempMail 邮箱 {email} 找到验证码: {code}")
                         self.update_status(True)
                         return code

--- a/src/services/tempmail.py
+++ b/src/services/tempmail.py
@@ -214,6 +214,10 @@ class TempmailService(BaseEmailService):
                     if not msg_date or msg_date in seen_ids:
                         continue
                     seen_ids.add(msg_date)
+                    message_marker = f"date:{msg_date}" if msg_date else None
+
+                    if self._is_message_before_otp(msg.get("date"), otp_sent_at):
+                        continue
 
                     sender = str(msg.get("from", "")).lower()
                     subject = str(msg.get("subject", ""))
@@ -230,6 +234,8 @@ class TempmailService(BaseEmailService):
                     match = re.search(pattern, content)
                     if match:
                         code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         logger.info(f"找到验证码: {code}")
                         self.update_status(True)
                         return code
@@ -368,6 +374,7 @@ class TempmailService(BaseEmailService):
                     if not msg_date or msg_date in seen_ids:
                         continue
                     seen_ids.add(msg_date)
+                    message_marker = f"date:{msg_date}" if msg_date else None
 
                     sender = str(msg.get("from", "")).lower()
                     subject = str(msg.get("subject", ""))
@@ -384,6 +391,8 @@ class TempmailService(BaseEmailService):
                     match = re.search(OTP_CODE_PATTERN, content)
                     if match:
                         code = match.group(1)
+                        if not self._accept_verification_code(email, code, message_marker):
+                            continue
                         if callback:
                             callback({
                                 "status": "found",

--- a/tests/test_mail_code_reuse_guard.py
+++ b/tests/test_mail_code_reuse_guard.py
@@ -1,0 +1,361 @@
+from src.services.duck_mail import DuckMailService
+from src.services.freemail import FreemailService
+from src.services.temp_mail import TempMailService
+from src.services.tempmail import TempmailService
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json payload")
+        return self._payload
+
+
+class FakeRequestHTTPClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "kwargs": kwargs,
+        })
+        if not self.responses:
+            raise AssertionError(f"未准备响应: {method} {url}")
+        return self.responses.pop(0)
+
+
+class FakeGetHTTPClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append({
+            "method": "GET",
+            "url": url,
+            "kwargs": kwargs,
+        })
+        if not self.responses:
+            raise AssertionError(f"未准备响应: GET {url}")
+        return self.responses.pop(0)
+
+
+def test_tempmail_service_skips_code_returned_by_previous_fetch():
+    service = TempmailService({"base_url": "https://api.tempmail.test"})
+    service.http_client = FakeGetHTTPClient([
+        FakeResponse(
+            payload={
+                "emails": [
+                    {
+                        "date": 1000,
+                        "from": "noreply@openai.com",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                    }
+                ]
+            }
+        ),
+        FakeResponse(
+            payload={
+                "emails": [
+                    {
+                        "date": 1000,
+                        "from": "noreply@openai.com",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                    },
+                    {
+                        "date": 1003,
+                        "from": "noreply@openai.com",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 654321",
+                    },
+                ]
+            }
+        ),
+    ])
+
+    first_code = service.get_verification_code(
+        email="tester@example.com",
+        email_id="token-1",
+        timeout=1,
+        otp_sent_at=1000,
+    )
+    second_code = service.get_verification_code(
+        email="tester@example.com",
+        email_id="token-1",
+        timeout=1,
+        otp_sent_at=1002,
+    )
+
+    assert first_code == "111111"
+    assert second_code == "654321"
+
+
+def test_temp_mail_service_skips_code_returned_by_previous_fetch():
+    service = TempMailService({
+        "base_url": "https://mail.example.com",
+        "admin_password": "admin-secret",
+        "domain": "example.com",
+    })
+    service.http_client = FakeRequestHTTPClient([
+        FakeResponse(
+            payload={
+                "results": [
+                    {
+                        "id": "msg-1",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                        "createdAt": "2026-03-19T10:00:00Z",
+                    }
+                ]
+            }
+        ),
+        FakeResponse(
+            payload={
+                "results": [
+                    {
+                        "id": "msg-1",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                        "createdAt": "2026-03-19T10:00:00Z",
+                    },
+                    {
+                        "id": "msg-2",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 654321",
+                        "createdAt": "2026-03-19T10:00:03Z",
+                    },
+                ]
+            }
+        ),
+    ])
+
+    first_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378400,
+    )
+    second_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378402,
+    )
+
+    assert first_code == "111111"
+    assert second_code == "654321"
+
+
+def test_temp_mail_service_accepts_same_code_from_newer_message():
+    service = TempMailService({
+        "base_url": "https://mail.example.com",
+        "admin_password": "admin-secret",
+        "domain": "example.com",
+    })
+    service.http_client = FakeRequestHTTPClient([
+        FakeResponse(
+            payload={
+                "results": [
+                    {
+                        "id": "msg-1",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                        "createdAt": "2026-03-19T10:00:00Z",
+                    }
+                ]
+            }
+        ),
+        FakeResponse(
+            payload={
+                "results": [
+                    {
+                        "id": "msg-1",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                        "createdAt": "2026-03-19T10:00:00Z",
+                    },
+                    {
+                        "id": "msg-2",
+                        "source": "OpenAI <noreply@openai.com>",
+                        "subject": "Your verification code",
+                        "body": "Your OpenAI verification code is 111111",
+                        "createdAt": "2026-03-19T10:00:03Z",
+                    },
+                ]
+            }
+        ),
+    ])
+
+    first_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378400,
+    )
+    second_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378402,
+    )
+
+    assert first_code == "111111"
+    assert second_code == "111111"
+
+
+def test_freemail_service_skips_code_returned_by_previous_fetch():
+    service = FreemailService({
+        "base_url": "https://mail.example.com",
+        "admin_token": "jwt-token",
+    })
+    service.http_client = FakeRequestHTTPClient([
+        FakeResponse(
+            payload=[
+                {
+                    "id": "msg-1",
+                    "sender": "noreply@openai.com",
+                    "subject": "Your verification code",
+                    "preview": "Your OpenAI verification code is 111111",
+                    "verification_code": "111111",
+                    "created_at": "2026-03-19T10:00:00Z",
+                }
+            ]
+        ),
+        FakeResponse(
+            payload=[
+                {
+                    "id": "msg-1",
+                    "sender": "noreply@openai.com",
+                    "subject": "Your verification code",
+                    "preview": "Your OpenAI verification code is 111111",
+                    "verification_code": "111111",
+                    "created_at": "2026-03-19T10:00:00Z",
+                },
+                {
+                    "id": "msg-2",
+                    "sender": "noreply@openai.com",
+                    "subject": "Your verification code",
+                    "preview": "Your OpenAI verification code is 654321",
+                    "verification_code": "654321",
+                    "created_at": "2026-03-19T10:00:03Z",
+                },
+            ]
+        ),
+    ])
+
+    first_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378400,
+    )
+    second_code = service.get_verification_code(
+        email="tester@example.com",
+        timeout=1,
+        otp_sent_at=1742378402,
+    )
+
+    assert first_code == "111111"
+    assert second_code == "654321"
+
+
+def test_duck_mail_service_skips_previously_used_code_even_with_small_timestamp_gap():
+    service = DuckMailService({
+        "base_url": "https://api.duckmail.test",
+        "default_domain": "duckmail.sbs",
+    })
+    service.http_client = FakeRequestHTTPClient([
+        FakeResponse(
+            payload={
+                "hydra:member": [
+                    {
+                        "id": "msg-1",
+                        "from": {
+                            "name": "OpenAI",
+                            "address": "noreply@openai.com",
+                        },
+                        "subject": "Your verification code",
+                        "createdAt": "2026-03-19T10:00:01Z",
+                    }
+                ]
+            }
+        ),
+        FakeResponse(
+            payload={
+                "id": "msg-1",
+                "text": "Your OpenAI verification code is 111111",
+                "html": [],
+            }
+        ),
+        FakeResponse(
+            payload={
+                "hydra:member": [
+                    {
+                        "id": "msg-1",
+                        "from": {
+                            "name": "OpenAI",
+                            "address": "noreply@openai.com",
+                        },
+                        "subject": "Your verification code",
+                        "createdAt": "2026-03-19T10:00:01Z",
+                    },
+                    {
+                        "id": "msg-2",
+                        "from": {
+                            "name": "OpenAI",
+                            "address": "noreply@openai.com",
+                        },
+                        "subject": "Your verification code",
+                        "createdAt": "2026-03-19T10:00:03Z",
+                    },
+                ]
+            }
+        ),
+        FakeResponse(
+            payload={
+                "id": "msg-1",
+                "text": "Your OpenAI verification code is 111111",
+                "html": [],
+            }
+        ),
+        FakeResponse(
+            payload={
+                "id": "msg-2",
+                "text": "Your OpenAI verification code is 654321",
+                "html": [],
+            }
+        ),
+    ])
+    service._accounts_by_email["tester@duckmail.sbs"] = {
+        "email": "tester@duckmail.sbs",
+        "service_id": "account-1",
+        "account_id": "account-1",
+        "token": "token-123",
+    }
+
+    first_code = service.get_verification_code(
+        email="tester@duckmail.sbs",
+        email_id="account-1",
+        timeout=1,
+        otp_sent_at=1742378401,
+    )
+    second_code = service.get_verification_code(
+        email="tester@duckmail.sbs",
+        email_id="account-1",
+        timeout=1,
+        otp_sent_at=1742378402,
+    )
+
+    assert first_code == "111111"
+    assert second_code == "654321"


### PR DESCRIPTION
## 问题背景

在验证码获取超时后，注册/登录流程会重新发送验证码并再次取码。

此前部分邮箱服务在第二次取码时没有正确隔离旧邮件，可能仍然返回第一次邮件里的旧验证码，导致重复使用过期验证码。

根据 issue 下的后续反馈，`moe_mail` 场景里即使已经做了取码隔离，仍然可能继续命中旧邮件。进一步排查后确认，`moe_mail` 返回的 `received_at` 使用的是毫秒级时间戳，如果按秒解析，会导致旧邮件时间过滤失效。

Closes #80

## 解决方案

本次修复将策略调整为：**优先识别新邮件，再以验证码去重作为兜底**，并补齐毫秒时间戳兼容。

具体改动包括：

- 在 `BaseEmailService` 中新增通用能力：
  - 邮件时间解析
  - 秒 / 毫秒 / 微秒级 Unix 时间戳归一化
  - 基于 `otp_sent_at` 的旧邮件过滤
  - 基于消息标识的去重
  - 基于验证码的兜底去重
- 更新以下邮箱服务的取码逻辑：
  - `tempmail`
  - `temp_mail`
  - `freemail`
  - `duck_mail`
  - `moe_mail`
- 处理规则调整为：
  - 老邮件中的旧验证码会被跳过
  - 新邮件即使和上一封邮件使用了相同验证码，也会被接受
  - 只有在拿不到可靠消息标识时，才退回到按验证码去重
- 针对 `moe_mail` 新增毫秒时间戳回归测试，确保旧邮件时间过滤生效

## 验证

已新增回归测试，覆盖以下场景：

- 第二次取码时跳过第一次邮件中的旧验证码
- 第二封邮件如果是新邮件，即使验证码相同，也应正常接受
- `moe_mail` 使用毫秒级 `received_at` 时，仍能正确跳过旧邮件并命中新邮件

本地测试结果：`24 passed`
