### PR TITLE
feat: add graceful shutdown with signal handler

### DIFF
--- a/src/core/http_client.py
+++ b/src/core/http_client.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class RequestConfig:
     """HTTP 请求配置"""
-    timeout: int = 30
+    timeout: int = 10  # 降低默认超时，让 Ctrl+C 响应更快
     max_retries: int = 3
     retry_delay: float = 1.0
     impersonate: str = "chrome"

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -5,6 +5,7 @@ FastAPI 应用主文件
 
 import logging
 import sys
+import signal
 import secrets
 import hmac
 import hashlib
@@ -25,6 +26,34 @@ from .routes.websocket import router as ws_router
 from .task_manager import task_manager
 
 logger = logging.getLogger(__name__)
+
+# 优雅退出标志
+_shutdown_requested = False
+
+
+def _signal_handler(signum, frame):
+    """信号处理器：Ctrl+C 时优雅退出"""
+    global _shutdown_requested
+    if _shutdown_requested:
+        logger.warning("收到第二次退出信号，强制退出")
+        sys.exit(1)
+    
+    _shutdown_requested = True
+    logger.info("收到退出信号，正在关闭...")
+    
+    # 取消所有运行中的任务
+    from .task_manager import _task_cancelled
+    for task_uuid in list(_task_cancelled.keys()):
+        task_manager.cancel_task(task_uuid)
+    
+    logger.info("已取消所有运行中的任务")
+    sys.exit(0)
+
+
+# 注册信号处理器
+signal.signal(signal.SIGINT, _signal_handler)
+if hasattr(signal, "SIGTERM"):
+    signal.signal(signal.SIGTERM, _signal_handler)
 
 # 获取项目根目录
 # PyInstaller 打包后静态资源在 sys._MEIPASS，开发时在源码根目录


### PR DESCRIPTION
## 问题

在 Windows 下运行注册任务时，Ctrl+C 经常无法停止进程。原因：
1. \curl_cffi\ 是 C 扩展，HTTP 请求期间信号处理器不会被调用
2. 线程池隔离，任务在子线程运行，信号发送到主线程
3. 默认 HTTP 超时 30 秒，阻塞时间长

## 改动

1. **添加信号处理器** (\src/web/app.py\)
   - 第一次 Ctrl+C：取消所有运行中任务并退出
   - 第二次 Ctrl+C：强制退出
   - 支持 SIGINT 和 SIGTERM

2. **降低默认 HTTP 超时** (\src/core/http_client.py\)
   - 30 秒 → 10 秒
   - 让 Ctrl+C 响应更快

## 测试

- Windows 10 + Python 3.13
- 启动任务后按 Ctrl+C，进程在 10 秒内退出
- 双击 Ctrl+C 立即强制退出